### PR TITLE
Expose cheerio for parsed pages

### DIFF
--- a/lib/tester.js
+++ b/lib/tester.js
@@ -139,6 +139,7 @@ var parsePages = function(files) {
         var $ = cheerio.load(fileContent);
         return Q.resolve({
         'path':filename,
+        '$': $,
         'content':$('section').html().trim()
       });
     });


### PR DESCRIPTION
I'm trying to implement tests for https://github.com/GitbookIO/plugin-styles-less

I need to access the whole page.